### PR TITLE
Changed reads and writes to 'rb' an 'wb' vs 'r' and 'w'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,10 +51,10 @@ Renew a certificate, using pkcs7csr and `certsrv <https://github.com/magnuswatn/
     from cryptography.hazmat.primitives import serialization
 
     # Read the certificate and key from file
-    with open('/etc/pki/tls/certs/my_adcs_cert.pem', 'r') as open_file:
+    with open('/etc/pki/tls/certs/my_adcs_cert.pem', 'rb') as open_file:
         cert = x509.load_pem_x509_certificate(open_file.read(), default_backend())
 
-    with open('/etc/pki/tls/private/my_adcs_key.pem', 'r') as open_file:
+    with open('/etc/pki/tls/private/my_adcs_key.pem', 'rb') as open_file:
         key = serialization.load_pem_private_key(
             open_file.read(),
             password=None,
@@ -69,7 +69,7 @@ Renew a certificate, using pkcs7csr and `certsrv <https://github.com/magnuswatn/
     pem_cert = certsrv.get_cert(csr, 'myTemplate')
 
     # Write the new cert to the file
-    with open('/etc/pki/tls/certs/my_adcs_cert.pem', 'w') as open_file:
+    with open('/etc/pki/tls/certs/my_adcs_cert.pem', 'wb') as open_file:
         open_file.write(pem_cert)
 
     # Reload apache or whatever here


### PR DESCRIPTION
I tried to run this on a server with Python 3.7.3 and received the
following exception:

	TypeError: argument 'data': 'str' object cannot be converted to 'PyBytes'

After a little digging it appears in Python 3 the call to open() needs a mode of ```'rb'``` vs ```'r'```.

I found my guidance for these changes here:
https://stackoverflow.com/questions/1035340/reading-binary-file-and-looping-over-each-byte

PS. I'm still quite "green" with Python in general (coming mostly from C# and Java experience).  So if I got something "wrong" let me know (I'm always willing and wanting to learn).

Thank you for pkcs7csr!!!!  After changing the "Example" in the
README.rst with the changes here it renewed my certificate like a charm.